### PR TITLE
Upgrade Baselines & make MPI dependency optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 
 FROM nvidia/cuda:10.0-runtime-ubuntu18.04
 ARG DEBIAN_FRONTEND=noninteractive
+ARG USE_MPI=True
 
 RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections \
     && apt-get update -q \
@@ -33,6 +34,12 @@ RUN add-apt-repository --yes ppa:deadsnakes/ppa \
 
 RUN curl -o /usr/local/bin/patchelf https://s3-us-west-2.amazonaws.com/openai-sci-artifacts/manual-builds/patchelf_0.9_amd64.elf \
     && chmod +x /usr/local/bin/patchelf
+
+RUN if [ $USE_MPI = "True" ]; then \
+    add-apt-repository --yes ppa:marmistrz/openmpi \
+    && apt-get update -q \
+    && apt-get install -y libopenmpi3 libopenmpi-dev; \
+    fi
 
 ENV LANG C.UTF-8
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib64:${LD_LIBRARY_PATH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,6 @@ RUN add-apt-repository --yes ppa:deadsnakes/ppa \
 RUN curl -o /usr/local/bin/patchelf https://s3-us-west-2.amazonaws.com/openai-sci-artifacts/manual-builds/patchelf_0.9_amd64.elf \
     && chmod +x /usr/local/bin/patchelf
 
-RUN add-apt-repository --yes ppa:marmistrz/openmpi \
-    && apt-get update -q \
-    && apt-get install -y libopenmpi3 libopenmpi-dev
-
 ENV LANG C.UTF-8
 ENV LD_LIBRARY_PATH /usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
 

--- a/ci/build_venv.sh
+++ b/ci/build_venv.sh
@@ -19,3 +19,7 @@ source ${venv}/bin/activate && \
 pip install -r requirements-build.txt && \
 pip install -r requirements.txt && \
 pip install -r requirements-${env}.txt
+
+if [[ $USE_MPI == "True" ]]; then
+  pip install mpi4py
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ Theano>=1.0
 sacred>=0.7.5
 pymongo>=3.8.0
 GitPython>=2.1
-git+git://github.com/HumanCompatibleAI/baselines.git@8978e3#egg=baselines
-git+git://github.com/HumanCompatibleAI/baselines.git@906d83#egg=stable-baselines
+git+git://github.com/HumanCompatibleAI/baselines.git@229a77#egg=baselines
+git+git://github.com/HumanCompatibleAI/baselines.git@153ce7#egg=stable-baselines
 ray[debug]>=0.7.0,<=0.7.2
 boto3>=1.9
 awscli>=1.16

--- a/src/modelfree/policies/base.py
+++ b/src/modelfree/policies/base.py
@@ -38,6 +38,9 @@ class DummyModel(BaseRLModel):
     def _get_pretrain_placeholders(self):
         raise NotImplementedError()
 
+    def get_parameter_list(self):
+        raise NotImplementedError()
+
 
 class PolicyToModel(DummyModel):
     """Converts BasePolicy to a BaseRLModel with only predict implemented."""

--- a/src/modelfree/policies/loader.py
+++ b/src/modelfree/policies/loader.py
@@ -5,7 +5,7 @@ import os
 import pickle
 import sys
 
-from stable_baselines import PPO1, PPO2, SAC
+import stable_baselines
 from stable_baselines.common.vec_env.vec_normalize import VecNormalize
 import tensorflow as tf
 
@@ -109,15 +109,22 @@ def load_random(path, env, env_name, index, transparent_params):
     return PolicyToModel(policy)
 
 
+# Lazy import for PPO1 and SAC, which have optional mpi dependency
 AGENT_LOADERS = {
     'zoo': load_zoo_agent,
-    'ppo1': load_stable_baselines(PPO1),
-    'ppo2': load_stable_baselines(PPO2),
-    'sac': load_stable_baselines(SAC),
+    'ppo2': load_stable_baselines(stable_baselines.PPO2),
     'old_ppo2': load_old_ppo2,
     'zero': load_zero,
     'random': load_random,
 }
+
+try:
+    # MPI algorithms -- only visible if mpi4py installed
+    from stable_baselines import PPO1, SAC
+    AGENT_LOADERS['ppo1'] = load_stable_baselines(PPO1)
+    AGENT_LOADERS['sac'] = load_stable_baselines(SAC)
+except ImportError:
+    pass
 
 
 def load_policy(policy_type, policy_path, env, env_name, index, transparent_params=None):

--- a/src/modelfree/policies/loader.py
+++ b/src/modelfree/policies/loader.py
@@ -109,6 +109,10 @@ def load_random(path, env, env_name, index, transparent_params):
     return PolicyToModel(policy)
 
 
+def mpi_unavailable_error(*args, **kwargs):
+    raise ImportError("This algorithm requires MPI, which is not available.")
+
+
 # Lazy import for PPO1 and SAC, which have optional mpi dependency
 AGENT_LOADERS = {
     'zoo': load_zoo_agent,
@@ -124,7 +128,8 @@ try:
     AGENT_LOADERS['ppo1'] = load_stable_baselines(PPO1)
     AGENT_LOADERS['sac'] = load_stable_baselines(SAC)
 except ImportError:
-    pass
+    AGENT_LOADERS['ppo1'] = mpi_unavailable_error
+    AGENT_LOADERS['sac'] = mpi_unavailable_error
 
 
 def load_policy(policy_type, policy_path, env, env_name, index, transparent_params=None):

--- a/src/modelfree/train.py
+++ b/src/modelfree/train.py
@@ -8,12 +8,10 @@ import os.path as osp
 import pkgutil
 
 from gym.spaces import Box
-import numpy as np
 from sacred import Experiment
 from sacred.observers import FileStorageObserver
-from stable_baselines import GAIL, PPO1, PPO2, SAC
+import stable_baselines
 from stable_baselines.common.vec_env.vec_normalize import VecNormalize
-from stable_baselines.gail.dataset.dataset import ExpertDataset
 import tensorflow as tf
 
 from aprl.envs.multi_agent import (FlattenSingletonVecEnv, MergeAgentVecEnv,
@@ -144,45 +142,17 @@ def _get_mpi_num_proc():
     return num_proc
 
 
-class ExpertDatasetFromOurFormat(ExpertDataset):
-    """GAIL Expert Dataset. Loads in our format, rather than the GAIL default.
-
-    In particular, GAIL expects a dict of flattened arrays, with episodes concatenated together.
-    The episode start is delineated by an `episode_starts` array. See `ExpertDataset` base class
-    for more information.
-
-    By contrast, our format consists of a list of NumPy arrays, one for each episode."""
-    def __init__(self, expert_path, **kwargs):
-        traj_data = np.load(expert_path, allow_pickle=True)
-
-        # Add in episode starts
-        episode_starts = []
-        for reward_dict in traj_data['rewards']:
-            ep_len = len(reward_dict)
-            # used to index episodes since they are flattened in GAIL format.
-            ep_starts = [True] + [False] * (ep_len - 1)
-            episode_starts.append(np.array(ep_starts))
-
-        # Flatten arrays
-        traj_data = {k: np.concatenate(v) for k, v in traj_data.items()}
-        traj_data['episode_starts'] = np.concatenate(episode_starts)
-
-        # Rename observations->obs
-        traj_data['obs'] = traj_data['observations']
-        del traj_data['observations']
-
-        super().__init__(traj_data=traj_data, **kwargs)
-
-
 @train_ex.capture
 def gail(batch_size, learning_rate, expert_dataset_path, **kwargs):
+    from modelfree.training.gail_dataset import ExpertDatasetFromOurFormat
     num_proc = _get_mpi_num_proc()
     if expert_dataset_path is None:
         raise ValueError("Must set expert_dataset_path to use GAIL.")
     expert_dataset = ExpertDatasetFromOurFormat(expert_dataset_path)
     kwargs['d_stepsize'] = learning_rate(1)
     kwargs['vf_stepsize'] = learning_rate(1)
-    return _stable(GAIL, our_type='gail', expert_dataset=expert_dataset,
+    return _stable(stable_baselines.GAIL, our_type='gail',
+                   expert_dataset=expert_dataset,
                    callback_key='timesteps_so_far', callback_mul=1,
                    timesteps_per_batch=batch_size // num_proc, **kwargs)
 
@@ -192,21 +162,24 @@ def ppo1(batch_size, learning_rate, **kwargs):
     num_proc = _get_mpi_num_proc()
     pylog.warning('Assuming constant learning rate schedule for PPO1')
     optim_stepsize = learning_rate(1)  # PPO1 does not support a callable learning_rate
-    return _stable(PPO1, our_type='ppo1', callback_key='timesteps_so_far',
-                   callback_mul=batch_size, timesteps_per_actorbatch=batch_size // num_proc,
+    return _stable(stable_baselines.PPO1, our_type='ppo1',
+                   callback_key='timesteps_so_far', callback_mul=batch_size,
+                   timesteps_per_actorbatch=batch_size // num_proc,
                    optim_stepsize=optim_stepsize, schedule='constant', **kwargs)
 
 
 @train_ex.capture
 def ppo2(batch_size, num_env, learning_rate, **kwargs):
-    return _stable(PPO2, our_type='ppo2', callback_key='update', callback_mul=batch_size,
+    return _stable(stable_baselines.PPO2, our_type='ppo2',
+                   callback_key='update', callback_mul=batch_size,
                    n_steps=batch_size // num_env, learning_rate=learning_rate, **kwargs)
 
 
 @train_ex.capture
 def sac(batch_size, learning_rate, **kwargs):
-    return _stable(SAC, our_type='sac', callback_key='step', callback_mul=1,
-                   batch_size=batch_size, learning_rate=learning_rate, **kwargs)
+    return _stable(stable_baselines.SAC, our_type='sac', callback_key='step',
+                   callback_mul=1, batch_size=batch_size,
+                   learning_rate=learning_rate, **kwargs)
 
 
 @train_ex.config
@@ -424,12 +397,21 @@ def single_wrappers(single_venv, scheduler, our_idx, normalize, rew_shape, rew_s
 
 
 RL_ALGOS = {
-    'gail': gail,
-    'ppo1': ppo1,
     'ppo2': ppo2,
     'old_ppo2': old_ppo2,
-    'sac': sac,
 }
+
+try:
+    from mpi4py import MPI
+    del MPI
+    RL_ALGOS.extend({
+        'gail': gail,
+        'ppo1': ppo1,
+        'sac': sac,
+    })
+except ImportError:
+    # Skip MPI-only algorithms
+    pass
 
 
 # True for Stable Baselines as of 2019-03

--- a/src/modelfree/train.py
+++ b/src/modelfree/train.py
@@ -404,7 +404,7 @@ RL_ALGOS = {
 try:
     from mpi4py import MPI
     del MPI
-    RL_ALGOS.extend({
+    RL_ALGOS.update({
         'gail': gail,
         'ppo1': ppo1,
         'sac': sac,

--- a/src/modelfree/train.py
+++ b/src/modelfree/train.py
@@ -21,7 +21,8 @@ from modelfree.envs.gym_compete import (GameOutcomeMonitor, GymCompeteToOurs,
                                         get_policy_type_for_zoo_agent, load_zoo_agent_params)
 from modelfree.envs.observation_masking import make_mask_agent_wrappers
 import modelfree.envs.wrappers
-from modelfree.policies.loader import load_backward_compatible_model, load_policy
+from modelfree.policies.loader import (load_backward_compatible_model, load_policy,
+                                       mpi_unavailable_error)
 from modelfree.training.logger import setup_logger
 from modelfree.training.lookback import (DebugVenv, LookbackRewardVecWrapper,
                                          OldMujocoResettableWrapper)
@@ -400,19 +401,18 @@ RL_ALGOS = {
     'ppo2': ppo2,
     'old_ppo2': old_ppo2,
 }
+MPI_RL_ALGOS = {
+    'gail': gail,
+    'ppo1': ppo1,
+    'sac': sac,
+}
 
 try:
     from mpi4py import MPI
     del MPI
-    RL_ALGOS.update({
-        'gail': gail,
-        'ppo1': ppo1,
-        'sac': sac,
-    })
+    RL_ALGOS.update(MPI_RL_ALGOS)
 except ImportError:
-    # Skip MPI-only algorithms
-    pass
-
+    RL_ALGOS.update({k: mpi_unavailable_error for k in MPI_RL_ALGOS})
 
 # True for Stable Baselines as of 2019-03
 NO_VECENV = ['ddpg', 'dqn', 'gail', 'her', 'ppo1', 'sac']

--- a/src/modelfree/training/gail_dataset.py
+++ b/src/modelfree/training/gail_dataset.py
@@ -1,0 +1,32 @@
+import numpy as np
+from stable_baselines.gail.dataset.dataset import ExpertDataset
+
+
+class ExpertDatasetFromOurFormat(ExpertDataset):
+    """GAIL Expert Dataset. Loads in our format, rather than the GAIL default.
+
+    In particular, GAIL expects a dict of flattened arrays, with episodes concatenated together.
+    The episode start is delineated by an `episode_starts` array. See `ExpertDataset` base class
+    for more information.
+
+    By contrast, our format consists of a list of NumPy arrays, one for each episode."""
+    def __init__(self, expert_path, **kwargs):
+        traj_data = np.load(expert_path, allow_pickle=True)
+
+        # Add in episode starts
+        episode_starts = []
+        for reward_dict in traj_data['rewards']:
+            ep_len = len(reward_dict)
+            # used to index episodes since they are flattened in GAIL format.
+            ep_starts = [True] + [False] * (ep_len - 1)
+            episode_starts.append(np.array(ep_starts))
+
+        # Flatten arrays
+        traj_data = {k: np.concatenate(v) for k, v in traj_data.items()}
+        traj_data['episode_starts'] = np.concatenate(episode_starts)
+
+        # Rename observations->obs
+        traj_data['obs'] = traj_data['observations']
+        del traj_data['observations']
+
+        super().__init__(traj_data=traj_data, **kwargs)

--- a/tests/modelfree/test_experiments.py
+++ b/tests/modelfree/test_experiments.py
@@ -138,11 +138,6 @@ TRAIN_CONFIGS = [
         'adv_noise_params': {'noise_val': 0.1},
     },
     {
-        'rl_algo': 'gail',
-        'num_env': 1,
-        'expert_dataset_path': os.path.join(BASE_DIR, 'SumoAnts_traj/agent_0.npz'),
-    },
-    {
         # test TransparentLSTMPolicy
         'transparent_params': ['ff_policy', 'hid'],
     },
@@ -158,6 +153,17 @@ TRAIN_CONFIGS = [
         'transparent_params': ['ff_policy'],
     },
 ]
+try:
+    from stable_baselines import GAIL
+    del GAIL
+    TRAIN_CONFIGS.append({
+        'rl_algo': 'gail',
+        'num_env': 1,
+        'expert_dataset_path': os.path.join(BASE_DIR, 'SumoAnts_traj/agent_0.npz'),
+    })
+except ImportError:
+    # skip GAIL test if algorithm not available
+    pass
 TRAIN_CONFIGS += [{'rl_algo': algo, 'num_env': 1 if algo in NO_VECENV else 8}
                   for algo in RL_ALGOS.keys() if algo != 'gail']
 


### PR DESCRIPTION
Removed MPI from Dockerfile.

We do still need it for some algorithms (PPO1, GAIL, SAC) but we're not using these right now, so let's avoid it for now, hopefully some of the bugs will get fixed before when we next need to use it.