### PR TITLE
Temporary workarounds for Ray bugs

### DIFF
--- a/src/modelfree/configs/ray/aws.yaml
+++ b/src/modelfree/configs/ray/aws.yaml
@@ -21,7 +21,7 @@ docker:
 provider:
   type: aws
   region: us-west-2
-  availability_zone: us-west-2a,us-west-2b,us-west-2c
+  availability_zone: us-west-2a,us-west-2b,us-west-2c,us-west2d
 
 # How Ray will authenticate with newly launched nodes.
 auth:

--- a/src/modelfree/configs/ray/aws.yaml
+++ b/src/modelfree/configs/ray/aws.yaml
@@ -53,7 +53,9 @@ worker_nodes:
     Name: EC2AccessS3
 
 # List of shell commands to run to set up nodes.
-initialization_commands: []  # before entering Docker
+initialization_commands:  # before entering Docker
+  # TODO(adam): remove once Ray #6111 merged
+  - docker pull humancompatibleai/adversarial_policies:latest
 setup_commands:
   # Part of Ray bug #4403 workaround.
   - ln -sf /root/.mujoco /home/ubuntu/.mujoco

--- a/src/modelfree/configs/ray/baremetal.yaml
+++ b/src/modelfree/configs/ray/baremetal.yaml
@@ -29,7 +29,9 @@ head_node: {}
 worker_nodes: {}
 
 # List of shell commands to run to set up nodes.
-initialization_commands: []  # before entering Docker
+initialization_commands:  # before entering Docker
+  # TODO(adam): remove once Ray #6111 merged
+  - docker pull humancompatibleai/adversarial_policies:latest
 setup_commands: []
 head_setup_commands: []
 worker_setup_commands: []

--- a/src/modelfree/multi/common.py
+++ b/src/modelfree/multi/common.py
@@ -167,13 +167,8 @@ def make_sacred(ex, worker_name, worker_fn):
             result = tune.run(trainable_name,
                               name=exp_id,
                               config=spec['config'],
-                              # We set checkpoint_freq > 0 so that Ray tries to resume after
-                              # failure. Unfortunately our trainable is a function and does
-                              # not support checkpointing. Just set it to a high enough frequency
-                              # that Ray never tries to checkpoint. (Normally >1 should be enough,
-                              # but if Ray restarts it that might count as a second iteration,
-                              # so just make it a moderately sized number.)
-                              checkpoint_freq=1000,
+                              # TODO(adam): delete next line when ray #6126 merged
+                              checkpoint_freq=10000000,
                               **spec['run_kwargs'])
         finally:
             ray.shutdown()

--- a/src/modelfree/multi/common.py
+++ b/src/modelfree/multi/common.py
@@ -167,6 +167,13 @@ def make_sacred(ex, worker_name, worker_fn):
             result = tune.run(trainable_name,
                               name=exp_id,
                               config=spec['config'],
+                              # We set checkpoint_freq > 0 so that Ray tries to resume after
+                              # failure. Unfortunately our trainable is a function and does
+                              # not support checkpointing. Just set it to a high enough frequency
+                              # that Ray never tries to checkpoint. (Normally >1 should be enough,
+                              # but if Ray restarts it that might count as a second iteration,
+                              # so just make it a moderately sized number.)
+                              checkpoint_freq=1000,
                               **spec['run_kwargs'])
         finally:
             ray.shutdown()


### PR DESCRIPTION
  - [X] Make Ray rune retry failed jobs. Somewhat hacky solution at present because `checkpoint_freq` does double-duty in Ray. I've reached out to the Ray maintainers to see if we can do something cleaner.
  - [X] Add extra AZ in AWS to be more likely to have spot instance requests fulfilled.
  - [X] Pull latest Docker image. Can remove workaround once https://github.com/ray-project/ray/pull/6111 is merged