### PR TITLE
Flexible configuration in multi.score

### DIFF
--- a/experiments/modelfree/attack_transfer.sh
+++ b/experiments/modelfree/attack_transfer.sh
@@ -7,7 +7,7 @@ OUT_ROOT=data/aws/score_agents
 TIMESTAMP=`date --iso-8601=seconds`
 
 function multi_score {
-  python -m aprl.multi.score with adversary_transfer "$@" high_accuracy
+  python -m aprl.multi.score with zoo_victim adversary_opponent "$@" high_accuracy
 }
 
 if [[ $# -eq 0 ]]; then

--- a/experiments/modelfree/attack_transfer.sh
+++ b/experiments/modelfree/attack_transfer.sh
@@ -7,7 +7,7 @@ OUT_ROOT=data/aws/score_agents
 TIMESTAMP=`date --iso-8601=seconds`
 
 function multi_score {
-  python -m aprl.multi.score with victims.zoo=zoo opponents.adversary=adversary "$@" high_accuracy
+  python -m aprl.multi.score with victims="[zoo]" opponents="[adversary]" "$@" high_accuracy
 }
 
 if [[ $# -eq 0 ]]; then

--- a/experiments/modelfree/attack_transfer.sh
+++ b/experiments/modelfree/attack_transfer.sh
@@ -7,7 +7,7 @@ OUT_ROOT=data/aws/score_agents
 TIMESTAMP=`date --iso-8601=seconds`
 
 function multi_score {
-  python -m aprl.multi.score with zoo_victim adversary_opponent "$@" high_accuracy
+  python -m aprl.multi.score with victims.zoo=zoo opponents.adversary=adversary "$@" high_accuracy
 }
 
 if [[ $# -eq 0 ]]; then

--- a/experiments/modelfree/baselines.sh
+++ b/experiments/modelfree/baselines.sh
@@ -12,16 +12,19 @@ OUT_DIR=data/aws/score_agents
 mkdir -p ${OUT_DIR}
 for kind in zoo fixed; do
     mkdir -p ${OUT_DIR}/normal
-    multi_score victims.zoo=zoo opponents.${kind}=${kind} save_path=${OUT_DIR}/normal/${kind}_baseline.json&
+    multi_score victims="[zoo]" opponents="[${kind}]" \
+                save_path=${OUT_DIR}/normal/${kind}_baseline.json&
     wait_proc
 
     mkdir -p ${OUT_DIR}/victim_masked_init
-    multi_score ${kind}_opponent mask_observations_of_victim \
+    multi_score victims="[zoo]" opponents="[${kind}]" \
+                mask_observations_of_victim \
                 save_path=${OUT_DIR}/victim_masked_init/${kind}_baseline.json&
     wait_proc
 
     mkdir -p ${OUT_DIR}/victim_masked_zero
-    multi_score ${kind}_opponent mask_observations_of_victim mask_observations_with_zeros \
+    multi_score victims="[zoo]" opponents="[${kind}]" \
+                mask_observations_of_victim mask_observations_with_zeros \
                 save_path=${OUT_DIR}/victim_masked_zero/${kind}_baseline.json&
     wait_proc
 done

--- a/experiments/modelfree/baselines.sh
+++ b/experiments/modelfree/baselines.sh
@@ -12,17 +12,17 @@ OUT_DIR=data/aws/score_agents
 mkdir -p ${OUT_DIR}
 for kind in zoo fixed; do
     mkdir -p ${OUT_DIR}/normal
-    multi_score ${kind}_baseline save_path=${OUT_DIR}/normal/${kind}_baseline.json&
+    multi_score zoo_victim ${kind}_opponent save_path=${OUT_DIR}/normal/${kind}_baseline.json&
     wait_proc
 
     mkdir -p ${OUT_DIR}/victim_masked_init
-    multi_score ${kind}_baseline mask_observations_of_victim \
+    multi_score ${kind}_opponent mask_observations_of_victim \
                 save_path=${OUT_DIR}/victim_masked_init/${kind}_baseline.json&
     wait_proc
 
     mkdir -p ${OUT_DIR}/victim_masked_zero
-    multi_score ${kind}_baseline mask_observations_of_victim mask_observations_with_zeros \
-           save_path=${OUT_DIR}/victim_masked_zero/${kind}_baseline.json&
+    multi_score ${kind}_opponent mask_observations_of_victim mask_observations_with_zeros \
+                save_path=${OUT_DIR}/victim_masked_zero/${kind}_baseline.json&
     wait_proc
 done
 

--- a/experiments/modelfree/baselines.sh
+++ b/experiments/modelfree/baselines.sh
@@ -12,7 +12,7 @@ OUT_DIR=data/aws/score_agents
 mkdir -p ${OUT_DIR}
 for kind in zoo fixed; do
     mkdir -p ${OUT_DIR}/normal
-    multi_score zoo_victim ${kind}_opponent save_path=${OUT_DIR}/normal/${kind}_baseline.json&
+    multi_score victims.zoo=zoo opponents.${kind}=${kind} save_path=${OUT_DIR}/normal/${kind}_baseline.json&
     wait_proc
 
     mkdir -p ${OUT_DIR}/victim_masked_init

--- a/experiments/modelfree/noisy_actions_and_obs.sh
+++ b/experiments/modelfree/noisy_actions_and_obs.sh
@@ -8,7 +8,7 @@ OUT_ROOT=${AWS_ROOT}/score_agents
 TIMESTAMP=`date --iso-8601=seconds`
 
 # Format: multi_score <opponent_type> <noise_type> ["extra_config1 ..."]
-# opponent_type: one of opponents.zoo=zoo or opponents.adversary=adversary
+# opponent_type: one of zoo or adversary
 # noise_type: one of ${NOISE_TYPES}
 # extra_config: a string with a list of space-separated named configs for aprl.multi.score
 # Saves to ${noise_type}/${TIMESTMAP}/${opponent_type}.json
@@ -17,8 +17,9 @@ function multi_score {
     noise_type=$2
     extra_configs=$3
 
-    python -m aprl.multi.score with victims.zoo=zoo ${opponent_type} ${noise_type} ${extra_configs} \
-              medium_accuracy save_path=${OUT_ROOT}/${noise_type}/${TIMESTAMP}/${opponent_type}.json
+    python -m aprl.multi.score with victims="[zoo]" opponents="[${opponent_type}]" \
+              ${noise_type} ${extra_configs} medium_accuracy \
+              save_path=${OUT_ROOT}/${noise_type}/${TIMESTAMP}/${opponent_type}.json
     wait_proc
 }
 
@@ -42,21 +43,21 @@ done
 
 export ADVERSARY_PATHS=${OUT_ROOT}/normal/2019-05-05T18:12:24+00:00/best_adversaries.json
 
-multi_score opponents.zoo=zoo noise_adversary_actions
+multi_score zoo noise_adversary_actions
 echo "Zoo baseline noisy actions completed"
 
-multi_score opponents.adversary=adversary noise_adversary_actions
+multi_score adversary noise_adversary_actions
 echo "Noisy actions completed"
 
-multi_score opponents.adversary=adversary noise_victim_actions
+multi_score adversary noise_victim_actions
 echo "Noisy victim actions completed"
 
-multi_score opponents.zoo=zoo mask_observations_with_additive_noise mask_observations_of_victim
-multi_score opponents.adversary=adversary mask_observations_with_additive_noise mask_observations_of_victim
+multi_score zoo mask_observations_with_additive_noise mask_observations_of_victim
+multi_score adversary mask_observations_with_additive_noise mask_observations_of_victim
 echo "Additive noise masking baseline complete"
 
-multi_score opponents.zoo=zoo mask_observations_with_smaller_additive_noise mask_observations_of_victim
-multi_score opponents.adversary=adversary mask_observations_with_smaller_additive_noise mask_observations_of_victim
+multi_score zoo mask_observations_with_smaller_additive_noise mask_observations_of_victim
+multi_score adversary mask_observations_with_smaller_additive_noise mask_observations_of_victim
 echo "Additive noise masking baseline complete"
 
 wait

--- a/experiments/modelfree/noisy_actions_and_obs.sh
+++ b/experiments/modelfree/noisy_actions_and_obs.sh
@@ -8,7 +8,7 @@ OUT_ROOT=${AWS_ROOT}/score_agents
 TIMESTAMP=`date --iso-8601=seconds`
 
 # Format: multi_score <opponent_type> <noise_type> ["extra_config1 ..."]
-# opponent_type: one of zoo_opponent or adversary_opponent
+# opponent_type: one of opponents.zoo=zoo or opponents.adversary=adversary
 # noise_type: one of ${NOISE_TYPES}
 # extra_config: a string with a list of space-separated named configs for aprl.multi.score
 # Saves to ${noise_type}/${TIMESTMAP}/${opponent_type}.json
@@ -17,7 +17,7 @@ function multi_score {
     noise_type=$2
     extra_configs=$3
 
-    python -m aprl.multi.score with zoo_victim ${opponent_type} ${noise_type} ${extra_configs} \
+    python -m aprl.multi.score with victims.zoo=zoo ${opponent_type} ${noise_type} ${extra_configs} \
               medium_accuracy save_path=${OUT_ROOT}/${noise_type}/${TIMESTAMP}/${opponent_type}.json
     wait_proc
 }
@@ -42,21 +42,21 @@ done
 
 export ADVERSARY_PATHS=${OUT_ROOT}/normal/2019-05-05T18:12:24+00:00/best_adversaries.json
 
-multi_score zoo_opponent noise_adversary_actions
+multi_score opponents.zoo=zoo noise_adversary_actions
 echo "Zoo baseline noisy actions completed"
 
-multi_score adversary_opponent noise_adversary_actions
+multi_score opponents.adversary=adversary noise_adversary_actions
 echo "Noisy actions completed"
 
-multi_score adversary_opponent noise_victim_actions
+multi_score opponents.adversary=adversary noise_victim_actions
 echo "Noisy victim actions completed"
 
-multi_score zoo_opponent mask_observations_with_additive_noise mask_observations_of_victim
-multi_score adversary_opponent mask_observations_with_additive_noise mask_observations_of_victim
+multi_score opponents.zoo=zoo mask_observations_with_additive_noise mask_observations_of_victim
+multi_score opponents.adversary=adversary mask_observations_with_additive_noise mask_observations_of_victim
 echo "Additive noise masking baseline complete"
 
-multi_score zoo_opponent mask_observations_with_smaller_additive_noise mask_observations_of_victim
-multi_score adversary_opponent mask_observations_with_smaller_additive_noise mask_observations_of_victim
+multi_score opponents.zoo=zoo mask_observations_with_smaller_additive_noise mask_observations_of_victim
+multi_score opponents.adversary=adversary mask_observations_with_smaller_additive_noise mask_observations_of_victim
 echo "Additive noise masking baseline complete"
 
 wait

--- a/experiments/modelfree/noisy_actions_and_obs.sh
+++ b/experiments/modelfree/noisy_actions_and_obs.sh
@@ -8,7 +8,7 @@ OUT_ROOT=${AWS_ROOT}/score_agents
 TIMESTAMP=`date --iso-8601=seconds`
 
 # Format: multi_score <opponent_type> <noise_type> ["extra_config1 ..."]
-# opponent_type: one of zoo_baseline or adversary_trained
+# opponent_type: one of zoo_opponent or adversary_opponent
 # noise_type: one of ${NOISE_TYPES}
 # extra_config: a string with a list of space-separated named configs for aprl.multi.score
 # Saves to ${noise_type}/${TIMESTMAP}/${opponent_type}.json
@@ -17,7 +17,7 @@ function multi_score {
     noise_type=$2
     extra_configs=$3
 
-    python -m aprl.multi.score with ${opponent_type} ${noise_type} ${extra_configs} \
+    python -m aprl.multi.score with zoo_victim ${opponent_type} ${noise_type} ${extra_configs} \
               medium_accuracy save_path=${OUT_ROOT}/${noise_type}/${TIMESTAMP}/${opponent_type}.json
     wait_proc
 }
@@ -42,21 +42,21 @@ done
 
 export ADVERSARY_PATHS=${OUT_ROOT}/normal/2019-05-05T18:12:24+00:00/best_adversaries.json
 
-multi_score zoo_baseline noise_adversary_actions
+multi_score zoo_opponent noise_adversary_actions
 echo "Zoo baseline noisy actions completed"
 
-multi_score adversary_trained noise_adversary_actions
+multi_score adversary_opponent noise_adversary_actions
 echo "Noisy actions completed"
 
-multi_score adversary_trained noise_victim_actions
+multi_score adversary_opponent noise_victim_actions
 echo "Noisy victim actions completed"
 
-multi_score zoo_baseline mask_observations_with_additive_noise mask_observations_of_victim
-multi_score adversary_trained mask_observations_with_additive_noise mask_observations_of_victim
+multi_score zoo_opponent mask_observations_with_additive_noise mask_observations_of_victim
+multi_score adversary_opponent mask_observations_with_additive_noise mask_observations_of_victim
 echo "Additive noise masking baseline complete"
 
-multi_score zoo_baseline mask_observations_with_smaller_additive_noise mask_observations_of_victim
-multi_score adversary_trained mask_observations_with_smaller_additive_noise mask_observations_of_victim
+multi_score zoo_opponent mask_observations_with_smaller_additive_noise mask_observations_of_victim
+multi_score adversary_opponent mask_observations_with_smaller_additive_noise mask_observations_of_victim
 echo "Additive noise masking baseline complete"
 
 wait

--- a/experiments/pull_s3.sh
+++ b/experiments/pull_s3.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-S3_SYNC_CMD="aws s3 sync --exclude='*/checkpoint/*' --exclude='*/datasets/*'"
+S3_SYNC_CMD="aws s3 sync --exclude=*/checkpoint/* --exclude=*/datasets/*"
 
 ${S3_SYNC_CMD} s3://adversarial-policies/ data/aws/
 ${S3_SYNC_CMD} s3://adversarial-policies-public/ data/aws-public/

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,8 +10,10 @@ force_sort_within_sections=True
 
 [tool:pytest]
 filterwarnings =
+    ignore:the imp module is deprecated in favour of importlib:DeprecationWarning:distutils
     ignore:Using or importing the ABCs from 'collections':DeprecationWarning:(google|pkg_resources|tensorflow|theano)
     ignore:inspect.getargspec:DeprecationWarning:tensorflow
+    ignore:Passing.* as a synonym of type is deprecated:FutureWarning:(tensorflow|tensorboard)
     ignore:inspect.getargspec:DeprecationWarning:ray
     ignore:Importing from numpy.testing:DeprecationWarning:theano
     ignore:Parameters to load are deprecated:Warning:gym

--- a/src/aprl/configs/multi/common.py
+++ b/src/aprl/configs/multi/common.py
@@ -3,6 +3,8 @@ import os
 
 from aprl.envs import gym_compete
 
+DATA_LOCATION = os.path.abspath(os.environ.get('DATA_LOC', 'data'))
+
 BANSAL_ENVS = ['multicomp/' + env for env in gym_compete.POLICY_STATEFUL.keys()]
 BANSAL_ENVS += ['multicomp/SumoHumansAutoContact-v0', 'multicomp/SumoAntsAutoContact-v0']
 BANSAL_GOOD_ENVS = [  # Environments well-suited to adversarial attacks

--- a/src/aprl/configs/multi/score.py
+++ b/src/aprl/configs/multi/score.py
@@ -330,8 +330,8 @@ def make_configs(multi_score_ex):
     def default_placeholders():
         spec = None
         envs = None
-        victims = {}
-        opponents = {}
+        victims = []
+        opponents = []
         exp_prefix = {}
 
         _ = locals()  # quieten flake8 unused variable warning
@@ -349,14 +349,14 @@ def make_configs(multi_score_ex):
             spec = {
                 'config': {
                     PATHS_AND_TYPES: tune.grid_search(
-                        _gen_configs(victim_fns=[_to_fn(cfg) for cfg in victims.values()],
-                                     opponent_fns=[_to_fn(cfg) for cfg in opponents.values()],
+                        _gen_configs(victim_fns=[_to_fn(cfg) for cfg in victims],
+                                     opponent_fns=[_to_fn(cfg) for cfg in opponents],
                                      envs=None if envs is None else envs.split(':'))
                     ),
                 }
             }
             exp_name = ((f"{':'.join(sorted(exp_prefix.keys()))}_" if exp_prefix else '') +
-                        f"{':'.join(victims.keys())}_vs_{':'.join(opponents.keys())}")
+                        f"{':'.join(victims)}_vs_{':'.join(opponents)}")
 
         _ = locals()  # quieten flake8 unused variable warning
         del _

--- a/src/aprl/configs/multi/score.py
+++ b/src/aprl/configs/multi/score.py
@@ -65,7 +65,7 @@ def _adversary():
 def _fixed(env, agent_index):
     """Returns all baseline, environment-independent policies."""
     del env, agent_index
-    return [('zero', 'none'), ('random', 'none')]
+    return [('random', 'none'), ('zero', 'none')]
 
 
 def _to_fn(cfg: str) -> AgentConfigGenFn:
@@ -293,7 +293,8 @@ def make_configs(multi_score_ex):
             'config': {
                 PATHS_AND_TYPES: tune.grid_search(
                     [EnvAgentConfig('multicomp/KickAndDefend-v0', 'zoo', '1', 'zoo', '1')] +
-                    _gen_configs(victim_fns=[_zoo], opponent_fns=[_fixed])[0:1]
+                    _gen_configs(victim_fns=[_zoo], opponent_fns=[_fixed],
+                                 envs=['multicomp/KickAndDefend-v0'])[0:1]
                 ),
             }
         }

--- a/src/aprl/configs/multi/score.py
+++ b/src/aprl/configs/multi/score.py
@@ -129,6 +129,10 @@ def make_configs(multi_score_ex):
 
     # ### Modifiers ###
     # You can use these with other configs.
+    # Note: these set singleton dictionaries `exp_prefix = {k: None}`, where k is the
+    # name of the named_config. These dictionaries are then merged by Sacred.
+    # The prefixes are then sorted and concatenated to be used as part of the experiment name.
+    # Note: only the keys are ever used, the values are ignored.
 
     # Accuracy
 
@@ -137,14 +141,14 @@ def make_configs(multi_score_ex):
         score = dict(score)
         score['episodes'] = 1000
         score['num_env'] = 16
-        exp_prefix = {'high_accuracy': 'high_accuracy'}  # noqa: F841
+        exp_prefix = {'high_accuracy': None}  # noqa: F841
 
     @multi_score_ex.named_config
     def medium_accuracy(score):
         score = dict(score)
         score['episodes'] = 100
         score['num_env'] = 16
-        exp_prefix = {'medium_accuracy': 'medium_accuracy'}  # noqa: F841
+        exp_prefix = {'medium_accuracy': None}  # noqa: F841
 
     # Artifacts: activations and/or videos
 
@@ -169,7 +173,7 @@ def make_configs(multi_score_ex):
                 }
             }
         }
-        exp_prefix = {'activations': 'activations'}  # noqa: F841
+        exp_prefix = {'activations': None}  # noqa: F841
 
     @multi_score_ex.named_config
     def video(score):
@@ -184,7 +188,7 @@ def make_configs(multi_score_ex):
                 'font_size': 70,
             }
         }
-        exp_prefix = {'video': 'video'}  # noqa: F841
+        exp_prefix = {'video': None}  # noqa: F841
 
     # Observation masking
 
@@ -197,7 +201,7 @@ def make_configs(multi_score_ex):
                 ),
             }
         }
-        exp_prefix = {'victim_mask': 'victim_mask'}  # noqa: F841
+        exp_prefix = {'victim_mask': None}  # noqa: F841
 
     @multi_score_ex.named_config
     def mask_observations_of_adversary():
@@ -208,13 +212,13 @@ def make_configs(multi_score_ex):
                 ),
             }
         }
-        exp_prefix = {'adversary_mask': 'adversary_mask'}  # noqa: F841
+        exp_prefix = {'adversary_mask': None}  # noqa: F841
 
     @multi_score_ex.named_config
     def mask_observations_with_zeros(score):
         score = dict(score)
         score['mask_agent_masking_type'] = 'zeros'
-        exp_prefix = {'zero': 'zero'}  # noqa: F841
+        exp_prefix = {'zero': None}  # noqa: F841
 
     def _mask_observations_with_additive_noise(score, agent_noise):
         score['index_keys'] = ['mask_agent_masking_type', 'mask_agent_noise']
@@ -233,7 +237,7 @@ def make_configs(multi_score_ex):
                 lambda _: np.random.lognormal(mean=0.5, sigma=1.5)
             )
         )
-        exp_prefix = {'additive_noise': 'additive_noise'}  # noqa: F841
+        exp_prefix = {'additive_noise': None}  # noqa: F841
 
     @multi_score_ex.named_config
     def mask_observations_with_smaller_additive_noise(score):
@@ -244,7 +248,7 @@ def make_configs(multi_score_ex):
                 lambda _: np.random.exponential(scale=1.0)
             )
         )
-        exp_prefix = {'smaller_additive_noise': 'smaller_additive_noise'}  # noqa: F841
+        exp_prefix = {'smaller_additive_noise': None}  # noqa: F841
 
     # Adding noise to actions
 
@@ -266,7 +270,7 @@ def make_configs(multi_score_ex):
         spec['config']['noisy_agent_index'] = tune.sample_from(
             lambda spec: 1 - VICTIM_INDEX[spec.config[PATHS_AND_TYPES][0]]
         )
-        exp_prefix = {'adversary_action_noise': 'adversary_action_noise'}  # noqa: F841
+        exp_prefix = {'adversary_action_noise': None}  # noqa: F841
 
     @multi_score_ex.named_config
     def noise_victim_actions(score):
@@ -275,7 +279,7 @@ def make_configs(multi_score_ex):
         spec['config']['noisy_agent_index'] = tune.sample_from(
             lambda spec: VICTIM_INDEX[spec.config[PATHS_AND_TYPES][0]]
         )
-        exp_prefix = {'victim_action_noise': 'victim_action_noise'}  # noqa: F841
+        exp_prefix = {'victim_action_noise': None}  # noqa: F841
 
     # ### Experimental Configs ###
     # These specify which agents to compare in which environments

--- a/src/aprl/configs/multi/score.py
+++ b/src/aprl/configs/multi/score.py
@@ -69,7 +69,14 @@ def _fixed(env, agent_index):
 
 
 def _to_fn(cfg: str) -> AgentConfigGenFn:
-    """Converts config of form cfg_type[:path] into a configuration function."""
+    """Converts config of form cfg_type[:path] into a configuration function.
+
+    Supported `cfg`'s are of the format:
+        zoo
+        fixed
+        adversary
+        json:/path/to/json
+    """
     cfg_type, *rem = cfg.split(':')
     if cfg_type == 'zoo':
         assert not rem
@@ -346,9 +353,11 @@ def make_configs(multi_score_ex):
         """Compare victims to opponents."""
         if spec is None:
             if not victims:
-                raise ValueError("You must specify the victims to compare with a modifier.")
+                raise ValueError("You must use a modifier config to specify the "
+                                 "victim policies to compare.")
             if not opponents:
-                raise ValueError("You must specify the opponents to compare with a modifier.")
+                raise ValueError("You must use a modifier config to specify the "
+                                 "opponent policies to compare.")
 
             spec = {
                 'config': {

--- a/src/aprl/configs/multi/train.py
+++ b/src/aprl/configs/multi/train.py
@@ -8,7 +8,8 @@ import os
 import numpy as np
 from ray import tune
 
-from aprl.configs.multi.common import BANSAL_ENVS, BANSAL_GOOD_ENVS, get_adversary_paths
+from aprl.configs.multi.common import (BANSAL_ENVS, BANSAL_GOOD_ENVS, DATA_LOCATION,
+                                       get_adversary_paths)
 from aprl.envs import VICTIM_INDEX, gym_compete
 
 MLP_ENVS = [env for env in BANSAL_ENVS if not gym_compete.is_stateful(env)]
@@ -41,8 +42,6 @@ HYPERPARAM_SEARCH_VALUES = {
     'learning_rate': tune.sample_from(
         lambda spec: 10 ** (-2 + -3 * np.random.random())),
 }
-
-DATA_LOCATION = os.path.abspath(os.environ.get('DATA_LOC', 'data'))
 
 
 def _env_victim(envs=None):

--- a/src/aprl/envs/__init__.py
+++ b/src/aprl/envs/__init__.py
@@ -1,8 +1,22 @@
 # flake8: noqa: F401
 import collections
 
-from gym.envs.registration import register
+import gym
+from gym.envs import registration
 from pkg_resources import resource_filename
+
+
+def register(id, **kwargs):
+    """Idempotent version of gym.envs.registration.registry.
+
+    Needed since aprl.envs can get imported multiple times, e.g. when deserializing policies.
+    """
+    try:
+        existing_spec = registration.spec(id)
+        new_spec = registration.EnvSpec(id, **kwargs)
+        assert existing_spec.__dict__ == new_spec.__dict__
+    except gym.error.UnregisteredEnv:  # not previously registered
+        registration.register(id, **kwargs)
 
 # Low-dimensional multi-agent environments
 

--- a/src/aprl/envs/gym_compete.py
+++ b/src/aprl/envs/gym_compete.py
@@ -42,6 +42,9 @@ SYMMETRIC_ENV = OrderedDict([
 def game_outcome(info):
     draw = True
     for i, agent_info in info.items():
+        if not isinstance(i, int):
+            # can have non-agent info keys, like 'terminal_observation'; skip
+            continue
         if 'winner' in agent_info:
             return i
     if draw:

--- a/src/aprl/multi/score.py
+++ b/src/aprl/multi/score.py
@@ -35,9 +35,7 @@ def default_config(score):
         },
         'config': {},
     }
-
     save_path = None      # path to save JSON results. If None, do not save.
-    exp_name = 'default'  # experiment name
 
     _ = locals()  # quieten flake8 unused variable warning
     del _

--- a/src/aprl/policies/loader.py
+++ b/src/aprl/policies/loader.py
@@ -147,6 +147,7 @@ def load_backward_compatible_model(cls, root_dir, denv=None, **kwargs):
     """Backwards compatibility hack to load old pickled policies
     which still expect modelfree.* to exist.
     """
+    import aprl.training.scheduling  # noqa: F401
     mock_modules = {
         'modelfree': 'aprl',
         'modelfree.scheduling': 'aprl.training.scheduling',


### PR DESCRIPTION
Change config of `aprl.multi.score` to based on modifiers specifying the victim and opponent policies, then take the Cartesian product of this pair.

This flexibility is particularly helpful now we need to compare finetuned victims to adversaries, etc.