### PR TITLE
Upgrade dependencies

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,6 @@ coverage:
     project:
       default: false
       main:
-        target: 80%
         paths:
           - "src/"
           - "!src/imitation/envs/examples/"
@@ -11,7 +10,6 @@ coverage:
       auxiliary:
         target: 0%
         paths:
-          - "src/aprl/beta/"
           - "src/aprl/configs/"
       tests:
         # Should not have dead code in our tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,12 +9,12 @@ pymongo>=3.8.0
 GitPython>=2.1
 baselines @ git+https://github.com/HumanCompatibleAI/baselines.git@f70377
 stable-baselines>=2.8.0
-ray[debug]>=0.7.6
+ray[debug,tune]>=0.7.6
 boto3>=1.9
 awscli>=1.16
 statsmodels>=0.9.0
 seaborn>=0.9.0
 ilqr @ git+https://github.com/anassinator/ilqr.git
-gym[mujoco]>=0.15.4
+gym[mujoco]==0.15.4
 mujoco-py-131 @ git+https://github.com/AdamGleave/mujoco-py.git@mj131
 gym_compete @ git+https://github.com/HumanCompatibleAI/multiagent-competition.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@ scikit-learn>=0.20.3
 Pillow>=6.0.0
 matplotlib>=3.0.3
 Theano>=1.0
-sacred>=0.8.0
+sacred>=0.8.1
 pymongo>=3.8.0
 GitPython>=2.1
 baselines @ git+https://github.com/HumanCompatibleAI/baselines.git@f70377
-stable-baselines>=2.8.0
-ray[debug,tune]>=0.7.6
+stable-baselines>=2.10.0
+ray[debug,tune]>=0.8.2
 boto3>=1.9
 awscli>=1.16
 statsmodels>=0.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,9 @@ filterwarnings =
     ignore:Parameters to load are deprecated:Warning:gym
     ignore:The binary mode of fromstring is deprecated:DeprecationWarning:gym
     ignore:.*TF Lite has moved from tf.contrib.lite to tf.lite:PendingDeprecationWarning
+    ignore:It appears you are loading from a file with old format. Older cloudpickle format has been replaced with zip-archived models. Consider saving the model with new format.:DeprecationWarning:stable_baselines
+    ignore:Loading model parameters from a list. This has been replaced with parameter dictionaries with variable names and parameters. If you are loading from a file, consider re-saving the file.:DeprecationWarning:stable_baselines
+    ignore:Usage of `load_running_average` is deprecated. Please use `load` or pickle instead.:DeprecationWarning:stable_baselines
 
 [pytype]
 inputs = aprl

--- a/src/aprl/activations/density/fit_density.py
+++ b/src/aprl/activations/density/fit_density.py
@@ -280,7 +280,7 @@ def fit_model(
        saving resulting models to output_root. Works by repeatedly calling `density_fitter`,
        running in parallel via Ray."""
     try:
-        ray.init(redis_address=ray_server, **init_kwargs)
+        ray.init(address=ray_server, **init_kwargs)
 
         # Find activation paths for each environment & victim-path tuple
         stem_pattern = re.compile(r"(.*)_opponent_.*\.npz")

--- a/src/aprl/activations/density/fit_density.py
+++ b/src/aprl/activations/density/fit_density.py
@@ -320,7 +320,7 @@ def fit_model(
                 paths,
                 output_dir,
                 model_class,
-                model_kwargs,
+                utils.sacred_copy(model_kwargs),
                 max_timesteps,
                 data_type,
                 train_opponent,

--- a/src/aprl/activations/tsne/fit_model.py
+++ b/src/aprl/activations/tsne/fit_model.py
@@ -123,7 +123,7 @@ def fit_model(
     data_type,
 ):
     try:
-        ray.init(redis_address=ray_server, **init_kwargs)
+        ray.init(address=ray_server, **init_kwargs)
 
         # Find activation paths for each environment & victim-path tuple
         stem_pattern = re.compile(r"(.*)_opponent_.*\.npz")

--- a/src/aprl/envs/multi_agent.py
+++ b/src/aprl/envs/multi_agent.py
@@ -88,6 +88,9 @@ class FakeSingleSpacesVec(VecEnv):
     def env_method(self, method_name, *method_args, indices=None, **method_kwargs):
         raise NotImplementedError()
 
+    def seed(self, seed):
+        raise NotImplementedError()
+
     def get_attr(self, attr_name, indices=None):
         raise NotImplementedError()
 

--- a/src/aprl/multi/common.py
+++ b/src/aprl/multi/common.py
@@ -174,13 +174,14 @@ def make_sacred(ex, worker_name, worker_fn):
         exp_id = f"{ex.path}/{exp_name}/{utils.make_timestamp()}-{uuid.uuid4().hex}"
         spec = utils.sacred_copy(spec)
 
+        # Disable TensorBoard logger: fails due to the spec containing string variables.
+        tune_loggers = [tune.logger.JsonLogger, tune.logger.CSVLogger]
         try:
             result = tune.run(
                 trainable_name,
                 name=exp_id,
                 config=spec["config"],
-                # TODO(adam): delete next line when ray #6126 merged
-                checkpoint_freq=10000000,
+                loggers=tune_loggers,
                 **spec["run_kwargs"],
             )
         finally:

--- a/src/aprl/multi/common.py
+++ b/src/aprl/multi/common.py
@@ -149,7 +149,7 @@ def make_sacred(ex, worker_name, worker_fn):
         exp_name: str,
         spec: Dict[str, Any],
     ) -> ray.tune.ExperimentAnalysis:
-        ray.init(redis_address=ray_server, **init_kwargs)
+        ray.init(address=ray_server, **init_kwargs)
 
         # We have to register the function we're going to call with Ray.
         # We partially apply worker_fn, so it's different for each experiment.

--- a/src/aprl/train.py
+++ b/src/aprl/train.py
@@ -149,7 +149,7 @@ def _stable(
             # We do not need to restore train_model, since it shares params with act_model
             model.act_model.restore(params)
     else:
-        model = cls(policy=policy, **kwargs)
+        model = cls(policy=policy, seed=_seed, **kwargs)
 
     last_checkpoint = 0
     last_log = 0
@@ -169,7 +169,7 @@ def _stable(
 
         return True  # keep training
 
-    model.learn(total_timesteps=total_timesteps, log_interval=1, seed=_seed, callback=callback)
+    model.learn(total_timesteps=total_timesteps, log_interval=1, callback=callback)
     final_path = osp.join(out_dir, "final_model")
     _save(model, final_path, save_callbacks)
     model.sess.close()

--- a/tests/policies/test_wrappers.py
+++ b/tests/policies/test_wrappers.py
@@ -46,8 +46,8 @@ class ConstantStatefulPolicy(BasePolicy):
         actions = np.array([self.constant] * self.n_env)
         return actions, None, state, None
 
-    def proba_step(self, obs, state=None, mask=None):
-        return self.step(obs, state=state, mask=mask)
+    def proba_step(self, obs, state=None, mask=None):  # pragma: no cover
+        raise NotImplementedError()
 
 
 def _get_constant_policy(venv, constant_value, state_shape=None):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -90,7 +90,7 @@ def check_monte_carlo(
         elif kind == "parallel":
             env_fns = [lambda: make_mujoco_env(env_name, seed) for _ in range(2)]
             mc = MonteCarloParallel(env_fns, planning_horizon, trajectories)
-        else:
+        else:  # pragma: no cover
             raise ValueError("Unrecognized kind '{}'".format(kind))
         mc.seed(seed)
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -163,7 +163,7 @@ try:
             "expert_dataset_path": os.path.join(BASE_DIR, "SumoAnts_traj/agent_0.npz"),
         }
     )
-except ImportError:
+except ImportError:  # pragma: no cover
     # skip GAIL test if algorithm not available
     pass
 TRAIN_CONFIGS += [


### PR DESCRIPTION
Upgrade Ray and Stable Baselines; fix various breakage from API changes.

Main changes:
  - Stable Baselines has a new callback mechanism. Eliminated some of our callback functionality which is now redundant.
  - Stable Baselines has a new load/save mechanism for `VecNormalize`; updated to use this while retaining backwards compatibility.
  - Various tweaks to new Ray API.