### PR TITLE
Add paper hyperparameters as config to train

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ experiment configuration.
 
 `aprl.train` trains a single adversarial policy. By default it will train on `SumoAnts` for
 a brief period of time. You can override any of config parameters, defined in `train_config`, at
-the command line. For example:
+the command line. For example, to replicate one of the experiments in the paper, run:
 
   ```bash
-  # Train on Sumo Humans for 10M timesteps
-  python -m aprl.train with env_name=multicomp/SumoHumans-v0 total_timesteps=10000000
+  # Train on Sumo Humans for 20M timesteps
+  python -m aprl.train with env_name=multicomp/SumoHumans-v0 paper
   ```
 
 `aprl.multi.train` trains multiple adversarial policies, using Ray (see below) for

--- a/src/aprl/configs/multi/train.py
+++ b/src/aprl/configs/multi/train.py
@@ -11,6 +11,7 @@ from ray import tune
 from aprl.configs import DATA_LOCATION
 from aprl.configs.multi.common import BANSAL_ENVS, BANSAL_GOOD_ENVS, get_adversary_paths
 from aprl.envs import VICTIM_INDEX, gym_compete
+from aprl.train import PAPER_HYPERPARAMS
 
 MLP_ENVS = [env for env in BANSAL_ENVS if not gym_compete.is_stateful(env)]
 LSTM_ENVS = [env for env in BANSAL_ENVS if gym_compete.is_stateful(env)]
@@ -51,14 +52,7 @@ def _sparse_reward(train):
 
 
 def _best_guess_train(train):
-    train["total_timesteps"] = int(10e6)
-    train["batch_size"] = 16384
-    train["learning_rate"] = 3e-4
-    train["rl_args"] = {
-        "ent_coef": 0.0,
-        "nminibatches": 4,
-        "noptepochs": 4,
-    }
+    train.update(**PAPER_HYPERPARAMS)
 
 
 def _best_guess_spec(envs=None):

--- a/src/aprl/configs/multi/train.py
+++ b/src/aprl/configs/multi/train.py
@@ -11,7 +11,7 @@ from ray import tune
 from aprl.configs import DATA_LOCATION
 from aprl.configs.multi.common import BANSAL_ENVS, BANSAL_GOOD_ENVS, get_adversary_paths
 from aprl.envs import VICTIM_INDEX, gym_compete
-from aprl.train import PAPER_HYPERPARAMS
+from aprl.train import PAPER_HYPERPARAMS, SPARSE_REWARD
 
 MLP_ENVS = [env for env in BANSAL_ENVS if not gym_compete.is_stateful(env)]
 LSTM_ENVS = [env for env in BANSAL_ENVS if gym_compete.is_stateful(env)]
@@ -47,8 +47,7 @@ def _env_victim(envs=None):
 
 
 def _sparse_reward(train):
-    train["rew_shape"] = True
-    train["rew_shape_params"] = {"anneal_frac": 0}
+    train.update(**SPARSE_REWARD)
 
 
 def _best_guess_train(train):

--- a/src/aprl/train.py
+++ b/src/aprl/train.py
@@ -352,6 +352,20 @@ def no_embed():
     del _
 
 
+PAPER_HYPERPARAMS = dict(
+    total_timesteps=int(20e6),
+    batch_size=16384,
+    learning_rate=3e-4,
+    rl_args=dict(ent_coef=0.0, nminibatches=4, noptepochs=4,),
+)
+
+
+@train_ex.named_config
+def paper():
+    """Same hyperparameters as ICLR 2020 paper."""
+    locals().update(**PAPER_HYPERPARAMS)
+
+
 @train_ex.capture
 def build_env(
     out_dir,

--- a/src/aprl/train.py
+++ b/src/aprl/train.py
@@ -388,14 +388,17 @@ PAPER_HYPERPARAMS = dict(
     total_timesteps=int(20e6),
     batch_size=16384,
     learning_rate=3e-4,
-    rl_args=dict(ent_coef=0.0, nminibatches=4, noptepochs=4,),
+    rl_args=dict(ent_coef=0.0, nminibatches=4, noptepochs=4),
 )
+
+SPARSE_REWARD = dict(rew_shape=True, rew_shape_params=dict(anneal_frac=0.0))
 
 
 @train_ex.named_config
 def paper():
     """Same hyperparameters as ICLR 2020 paper."""
     locals().update(**PAPER_HYPERPARAMS)
+    locals().update(**SPARSE_REWARD)
 
 
 @train_ex.capture


### PR DESCRIPTION
Currently only way to replicate paper is via `aprl.multi.train`, but this is heavyweight for many purposes. Add the paper hyperparameters to a named config in `aprl.train` for ease of replication.