### PR TITLE
Authenticate to Docker on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ executors:
   my-executor:
     docker:
       - image: humancompatibleai/adversarial_policies:base
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     working_directory: /adversarial-policies
     environment:
       # If you change these, also change scripts/code_checks.sh
@@ -120,6 +123,10 @@ workflows:
   test:
     jobs:
       - lintandtype:
-          context: MuJoCo
+          context:
+          - MuJoCo
+          - docker-hub-creds
       - unit-test:
-          context: MuJoCo
+          context:
+          - MuJoCo
+          - docker-hub-creds


### PR DESCRIPTION
From [CircleCI](https://circleci.com/docs/2.0/private-images/):

> Starting November 1, 2020, Docker Hub will impose rate limits based on the originating IP. Since CircleCI runs jobs from a shared pool of IPs, it is highly recommended to use authenticated Docker pulls with Docker Hub to avoid rate limit problems.

This PR adds authentication via a CircleCI context.